### PR TITLE
Use correct architectures value in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,4 +1,4 @@
-architectures=atmega328p
+architectures=avr
 author=Frank Denis <libhydrogen@pureftpd.org>
 category=Other
 includes=hydrogen.h


### PR DESCRIPTION
The previous architectures value causes the warning on every compilation:

WARNING: library hydrogen-crypto claims to run on (atmega328p) architecture(s) and may be incompatible with your current board which runs on (avr) architecture(s).