### PR TITLE
added support for esp-based system to hydo_random_init()

### DIFF
--- a/impl/random.h
+++ b/impl/random.h
@@ -66,6 +66,37 @@ hydro_random_init(void)
 }
 
 ISR(WDT_vect) {}
+#elif (defined(ESP32) || defined(ESP8266)) && !defined(__unix__)
+
+// Should be truely random if RF is activated on ESP board https://techtutorialsx.com/2017/12/22/esp32-arduino-random-number-generation/
+
+#include <esp_system.h>
+
+static int
+hydro_random_init(void)
+{
+    const char       ctx[hydro_hash_CONTEXTBYTES] = { 'h', 'y', 'd', 'r', 'o', 'P', 'R', 'G' };
+    hydro_hash_state st;
+    uint16_t         ebits = 0;
+    uint16_t         tc;
+    bool             a, b;
+
+
+    hydro_hash_init(&st, ctx, NULL);
+
+    while (ebits < 256) {
+        uint32_t r = esp_random();
+
+        delay(10);
+        hydro_hash_update(&st, (const uint32_t *) &r, sizeof r);
+        ebits += 32;
+    }
+
+    hydro_hash_final(&st, hydro_random_context.state, sizeof hydro_random_context.state);
+    hydro_random_context.counter = ~LOAD64_LE(hydro_random_context.state);
+
+    return 0;
+}
 
 #elif defined(_WIN32)
 


### PR DESCRIPTION
This code uses the random number generator present on ESP32 and ESP8266 based systems.
More information on esp32 random numbers can be found here https://techtutorialsx.com/2017/12/22/esp32-arduino-random-number-generation/ and the links contained in the blog post. For best results the radio interfaces (WiFi or Bluetooth) should be activated prior to calling the esp_random() function.

I'm using this code on heltec wifi lora 32 boards with platformio as build environment and it works just fine.