### PR TITLE
Fix Arduino build

### DIFF
--- a/Makefile.arduino
+++ b/Makefile.arduino
@@ -25,7 +25,8 @@ SRC = \
 	impl/random.h \
 	impl/secretbox.h \
 	impl/sign.h \
-	impl/x25519.h
+	impl/x25519.h \
+	impl/gimli-core/portable.h
 
 all: lib package
 


### PR DESCRIPTION
Using the LibHydrogen zip produced by this makefile for Arduino Nano failed because impl/gimli-core/portable.h wasn't packaged in the zip.