### PR TITLE
helper function for keyless gen hashes

### DIFF
--- a/hydrogen.h
+++ b/hydrogen.h
@@ -81,6 +81,9 @@ int hydro_hash_hash(uint8_t *out, size_t out_len, const void *in_, size_t in_len
                     const char    ctx[hydro_hash_CONTEXTBYTES],
                     const uint8_t key[hydro_hash_KEYBYTES]);
 
+int hydro_hash_keyless(uint8_t *out, size_t out_len, const void *in_, size_t in_len,
+                    const char    ctx[hydro_hash_CONTEXTBYTES]);
+
 /* ---------------- */
 
 #define hydro_secretbox_CONTEXTBYTES 8

--- a/impl/hash.h
+++ b/impl/hash.h
@@ -131,6 +131,11 @@ hydro_hash_hash(uint8_t *out, size_t out_len, const void *in_, size_t in_len,
     return 0;
 }
 
+int hydro_hash_keyless(uint8_t *out, size_t out_len, const void *in_, size_t in_len, const char ctx[hydro_hash_CONTEXTBYTES])
+{
+  return hydro_hash_hash(out, out_len, in_, in_len, ctx, NULL);
+}
+
 void
 hydro_hash_keygen(uint8_t key[hydro_hash_KEYBYTES])
 {

--- a/tests/tests.c
+++ b/tests/tests.c
@@ -108,6 +108,9 @@ test_hash(void)
     hydro_hash_hash(h, hydro_hash_BYTES, msg, sizeof msg, ctx, key);
     hydro_bin2hex(hex, sizeof hex, h, hydro_hash_BYTES);
     assert_streq("7dfa45ce18210e2422fd658bf7beccb6e534e44f99ae359f4af3ba41af8ca463", hex);
+    hydro_hash_keyless(h, hydro_hash_BYTES, msg, sizeof msg, ctx);
+    hydro_bin2hex(hex, sizeof hex, h, hydro_hash_BYTES);
+    assert_streq("2ceed670db04f2653b295d7727232efbab96860c7a81d8dc4a68cd53bbaa504d", hex);
 }
 
 static void


### PR DESCRIPTION
As the title says, merely a helper function for keyless generic hashes. This may be undesirable in libhydrogen, but will help keep my bindings a bit more simple, so figured the PR was worth a shot. 

Cheers!