### PR TITLE
Disable system dialog when tests fail on Windows

### DIFF
--- a/tests/tests.c
+++ b/tests/tests.c
@@ -411,6 +411,12 @@ test_pwhash(void)
 int
 main(void)
 {
+#if defined(_WIN32)
+    // On Windows, disable the "Abort - Retry - Ignore" GUI dialog that otherwise pops up on
+    // assertion failure.
+    _set_abort_behavior(0, _WRITE_ABORT_MSG | _CALL_REPORTFAULT);
+#endif
+
     int ret;
 
     ret = hydro_init();


### PR DESCRIPTION
By default, when an `assert` fails in a debug binary on Windows, the system pops up a GUI dialog box asking whether it should Abort/Retry/Ignore in response to the failure, pausing program execution until one of these options is manually selected. Not good for automatic test runs!