### PR TITLE
Header guards and includes

### DIFF
--- a/impl/common.h
+++ b/impl/common.h
@@ -1,3 +1,13 @@
+#ifndef hydrogen_common_H
+#define hydrogen_common_H
+
+#ifdef __cplusplus
+# ifdef __GNUC__
+#  pragma GCC diagnostic ignored "-Wlong-long"
+# endif
+extern "C" {
+#endif
+
 #include <assert.h>
 #include <errno.h>
 #include <limits.h>
@@ -320,3 +330,9 @@ mem_xor2(void *__restrict__ dst_, const void *__restrict__ src1_, const void *__
 }
 
 static const uint8_t zero[64] = { 0 };
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* hydrogen_common_H */

--- a/impl/core.h
+++ b/impl/core.h
@@ -1,3 +1,13 @@
+#ifndef hydrogen_core_H
+#define hydrogen_core_H
+
+#ifdef __cplusplus
+# ifdef __GNUC__
+#  pragma GCC diagnostic ignored "-Wlong-long"
+# endif
+extern "C" {
+#endif
+
 int
 hydro_init(void)
 {
@@ -222,3 +232,9 @@ hydro_unpad(const unsigned char *buf, size_t padded_buflen, size_t blocksize)
     }
     return (int) (padded_buflen - 1 - pad_len);
 }
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* hydrogen_core_H */

--- a/impl/core.h
+++ b/impl/core.h
@@ -8,6 +8,9 @@
 extern "C" {
 #endif
 
+#include "common.h"
+#include "random.h"
+
 int
 hydro_init(void)
 {

--- a/impl/gimli-core.h
+++ b/impl/gimli-core.h
@@ -14,6 +14,9 @@ extern "C" {
 # include "gimli-core/portable.h"
 #endif
 
+#include "common.h"
+#include "hydrogen_p.h"
+
 static void
 gimli_core_u8(uint8_t state_u8[gimli_BLOCKBYTES], uint8_t tag)
 {

--- a/impl/gimli-core.h
+++ b/impl/gimli-core.h
@@ -1,3 +1,13 @@
+#ifndef hydrogen_gimli_core_H
+#define hydrogen_gimli_core_H
+
+#ifdef __cplusplus
+# ifdef __GNUC__
+#  pragma GCC diagnostic ignored "-Wlong-long"
+# endif
+extern "C" {
+#endif
+
 #ifdef __SSE2__
 # include "gimli-core/sse2.h"
 #else
@@ -23,3 +33,9 @@ gimli_core_u8(uint8_t state_u8[gimli_BLOCKBYTES], uint8_t tag)
     gimli_core((uint32_t *) (void *) state_u8); /* state_u8 must be properly aligned */
 #endif
 }
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* hydrogen_gimli_core_H */

--- a/impl/gimli-core/portable.h
+++ b/impl/gimli-core/portable.h
@@ -8,6 +8,9 @@
 extern "C" {
 #endif
 
+#include <stdint.h>
+#include "../hydrogen_p.h"
+
 static void
 gimli_core(uint32_t state[gimli_BLOCKBYTES / 4])
 {

--- a/impl/gimli-core/portable.h
+++ b/impl/gimli-core/portable.h
@@ -1,3 +1,13 @@
+#ifndef hydrogen_gimli_core_portable_H
+#define hydrogen_gimli_core_portable_H
+
+#ifdef __cplusplus
+# ifdef __GNUC__
+#  pragma GCC diagnostic ignored "-Wlong-long"
+# endif
+extern "C" {
+#endif
+
 static void
 gimli_core(uint32_t state[gimli_BLOCKBYTES / 4])
 {
@@ -37,3 +47,9 @@ gimli_core(uint32_t state[gimli_BLOCKBYTES / 4])
         }
     }
 }
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* hydrogen_gimli_core_portable_H */

--- a/impl/gimli-core/sse2.h
+++ b/impl/gimli-core/sse2.h
@@ -9,8 +9,9 @@ extern "C" {
 #endif
 
 #ifdef __SSE2__
-
+#include <stdint.h>
 #include <tmmintrin.h>
+#include "../hydrogen_p.h"
 
 #define S 9
 
@@ -107,7 +108,8 @@ gimli_core(uint32_t state[gimli_BLOCKBYTES / 4])
     _mm_storeu_si128((__m128i *) (void *) &state[4], y);
     _mm_storeu_si128((__m128i *) (void *) &state[8], z);
 }
-
+#else
+# error "This header should be included only for SSE2 capable processors"
 #endif /* __SSE2__ */
 
 #ifdef __cplusplus

--- a/impl/gimli-core/sse2.h
+++ b/impl/gimli-core/sse2.h
@@ -1,3 +1,15 @@
+#ifndef hydrogen_gimli_core_sse2_H
+#define hydrogen_gimli_core_sse2_H
+
+#ifdef __cplusplus
+# ifdef __GNUC__
+#  pragma GCC diagnostic ignored "-Wlong-long"
+# endif
+extern "C" {
+#endif
+
+#ifdef __SSE2__
+
 #include <tmmintrin.h>
 
 #define S 9
@@ -95,3 +107,11 @@ gimli_core(uint32_t state[gimli_BLOCKBYTES / 4])
     _mm_storeu_si128((__m128i *) (void *) &state[4], y);
     _mm_storeu_si128((__m128i *) (void *) &state[8], z);
 }
+
+#endif /* __SSE2__ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* hydrogen_gimli_core_sse2_H */

--- a/impl/hash.h
+++ b/impl/hash.h
@@ -1,3 +1,13 @@
+#ifndef hydrogen_hash_H
+#define hydrogen_hash_H
+
+#ifdef __cplusplus
+# ifdef __GNUC__
+#  pragma GCC diagnostic ignored "-Wlong-long"
+# endif
+extern "C" {
+#endif
+
 int
 hydro_hash_update(hydro_hash_state *state, const void *in_, size_t in_len)
 {
@@ -136,3 +146,9 @@ hydro_hash_keygen(uint8_t key[hydro_hash_KEYBYTES])
 {
     hydro_random_buf(key, hydro_hash_KEYBYTES);
 }
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* hydrogen_hash_H */

--- a/impl/hash.h
+++ b/impl/hash.h
@@ -8,6 +8,9 @@
 extern "C" {
 #endif
 
+#include "common.h"
+#include "hydrogen_p.h"
+
 int
 hydro_hash_update(hydro_hash_state *state, const void *in_, size_t in_len)
 {

--- a/impl/hydrogen_p.h
+++ b/impl/hydrogen_p.h
@@ -8,6 +8,9 @@
 extern "C" {
 #endif
 
+#include "common.h"
+#include "../hydrogen.h"
+
 static int hydro_random_init(void);
 
 /* ---------------- */

--- a/impl/hydrogen_p.h
+++ b/impl/hydrogen_p.h
@@ -1,3 +1,13 @@
+#ifndef hydrogen_hydrogen_p_H
+#define hydrogen_hydrogen_p_H
+
+#ifdef __cplusplus
+# ifdef __GNUC__
+#  pragma GCC diagnostic ignored "-Wlong-long"
+# endif
+extern "C" {
+#endif
+
 static int hydro_random_init(void);
 
 /* ---------------- */
@@ -81,3 +91,9 @@ static inline int hydro_x25519_scalarmult_base(uint8_t       pk[hydro_x25519_PUB
 static inline void
 hydro_x25519_scalarmult_base_uniform(uint8_t       pk[hydro_x25519_PUBLICKEYBYTES],
                                      const uint8_t sk[hydro_x25519_SECRETKEYBYTES]);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* hydrogen_hydrogen_p_H */

--- a/impl/kdf.h
+++ b/impl/kdf.h
@@ -8,6 +8,9 @@
 extern "C" {
 #endif
 
+#include "common.h"
+#include "hydrogen_p.h"
+
 int
 hydro_kdf_derive_from_key(uint8_t *subkey, size_t subkey_len, uint64_t subkey_id,
                           const char    ctx[hydro_kdf_CONTEXTBYTES],

--- a/impl/kdf.h
+++ b/impl/kdf.h
@@ -1,3 +1,13 @@
+#ifndef hydrogen_kdf_H
+#define hydrogen_kdf_H
+
+#ifdef __cplusplus
+# ifdef __GNUC__
+#  pragma GCC diagnostic ignored "-Wlong-long"
+# endif
+extern "C" {
+#endif
+
 int
 hydro_kdf_derive_from_key(uint8_t *subkey, size_t subkey_len, uint64_t subkey_id,
                           const char    ctx[hydro_kdf_CONTEXTBYTES],
@@ -18,3 +28,9 @@ hydro_kdf_keygen(uint8_t key[hydro_kdf_KEYBYTES])
 {
     hydro_random_buf(key, hydro_kdf_KEYBYTES);
 }
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* hydrogen_kdf_H */

--- a/impl/kx.h
+++ b/impl/kx.h
@@ -8,6 +8,10 @@
 extern "C" {
 #endif
 
+#include "common.h"
+#include "random.h"
+#include "hydrogen_p.h"
+
 #define hydro_kx_AEAD_KEYBYTES hydro_hash_KEYBYTES
 #define hydro_kx_AEAD_MACBYTES 16
 #define hydro_kx_AEAD_HEADERBYTES hydro_kx_AEAD_MACBYTES

--- a/impl/kx.h
+++ b/impl/kx.h
@@ -1,3 +1,13 @@
+#ifndef hydrogen_kx_H
+#define hydrogen_kx_H
+
+#ifdef __cplusplus
+# ifdef __GNUC__
+#  pragma GCC diagnostic ignored "-Wlong-long"
+# endif
+extern "C" {
+#endif
+
 #define hydro_kx_AEAD_KEYBYTES hydro_hash_KEYBYTES
 #define hydro_kx_AEAD_MACBYTES 16
 #define hydro_kx_AEAD_HEADERBYTES hydro_kx_AEAD_MACBYTES
@@ -439,3 +449,9 @@ hydro_kx_xx_4(hydro_kx_state *state, hydro_kx_session_keypair *kp,
 
     return 0;
 }
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* hydrogen_kx_H */

--- a/impl/pwhash.h
+++ b/impl/pwhash.h
@@ -8,6 +8,9 @@
 extern "C" {
 #endif
 
+#include "common.h"
+#include "hydrogen_p.h"
+
 #define hydro_pwhash_ENC_ALGBYTES 1
 #define hydro_pwhash_HASH_ALGBYTES 1
 #define hydro_pwhash_THREADSBYTES 1

--- a/impl/pwhash.h
+++ b/impl/pwhash.h
@@ -1,3 +1,13 @@
+#ifndef hydrogen_pwhash_H
+#define hydrogen_pwhash_H
+
+#ifdef __cplusplus
+# ifdef __GNUC__
+#  pragma GCC diagnostic ignored "-Wlong-long"
+# endif
+extern "C" {
+#endif
+
 #define hydro_pwhash_ENC_ALGBYTES 1
 #define hydro_pwhash_HASH_ALGBYTES 1
 #define hydro_pwhash_THREADSBYTES 1
@@ -279,3 +289,9 @@ hydro_pwhash_upgrade(uint8_t       stored[hydro_pwhash_STOREDBYTES],
     return hydro_secretbox_encrypt(secretbox, params, hydro_pwhash_PARAMSBYTES, (uint64_t) *enc_alg,
                                    hydro_pwhash_CONTEXT, master_key);
 }
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* hydrogen_pwhash_H */

--- a/impl/random.h
+++ b/impl/random.h
@@ -8,6 +8,9 @@
 extern "C" {
 #endif
 
+#include "common.h"
+#include "hydrogen_p.h"
+
 static TLS struct {
     _hydro_attr_aligned_(16) uint8_t state[gimli_BLOCKBYTES];
     uint64_t counter;

--- a/impl/random.h
+++ b/impl/random.h
@@ -1,3 +1,13 @@
+#ifndef hydrogen_random_H
+#define hydrogen_random_H
+
+#ifdef __cplusplus
+# ifdef __GNUC__
+#  pragma GCC diagnostic ignored "-Wlong-long"
+# endif
+extern "C" {
+#endif
+
 static TLS struct {
     _hydro_attr_aligned_(16) uint8_t state[gimli_BLOCKBYTES];
     uint64_t counter;
@@ -436,3 +446,9 @@ hydro_random_reseed(void)
     hydro_random_context.initialized = 0;
     hydro_random_check_initialized();
 }
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* hydrogen_random_H */

--- a/impl/secretbox.h
+++ b/impl/secretbox.h
@@ -8,6 +8,9 @@
 extern "C" {
 #endif
 
+#include "common.h"
+#include "hydrogen_p.h"
+
 #define hydro_secretbox_IVBYTES 20
 #define hydro_secretbox_SIVBYTES 20
 #define hydro_secretbox_MACBYTES 16

--- a/impl/secretbox.h
+++ b/impl/secretbox.h
@@ -1,3 +1,13 @@
+#ifndef hydrogen_secretbox_H
+#define hydrogen_secretbox_H
+
+#ifdef __cplusplus
+# ifdef __GNUC__
+#  pragma GCC diagnostic ignored "-Wlong-long"
+# endif
+extern "C" {
+#endif
+
 #define hydro_secretbox_IVBYTES 20
 #define hydro_secretbox_SIVBYTES 20
 #define hydro_secretbox_MACBYTES 16
@@ -234,3 +244,9 @@ hydro_secretbox_decrypt(void *m_, const uint8_t *c, size_t clen, uint64_t msg_id
     }
     return 0;
 }
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* hydrogen_secretbox_H */

--- a/impl/sign.h
+++ b/impl/sign.h
@@ -1,3 +1,13 @@
+#ifndef hydrogen_sign_H
+#define hydrogen_sign_H
+
+#ifdef __cplusplus
+# ifdef __GNUC__
+#  pragma GCC diagnostic ignored "-Wlong-long"
+# endif
+extern "C" {
+#endif
+
 #define hydro_sign_CHALLENGEBYTES 32
 #define hydro_sign_NONCEBYTES 32
 #define hydro_sign_PREHASHBYTES 64
@@ -205,3 +215,9 @@ hydro_sign_verify(const uint8_t csig[hydro_sign_BYTES], const void *m_, size_t m
     }
     return 0;
 }
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* hydrogen_sign_H */

--- a/impl/sign.h
+++ b/impl/sign.h
@@ -8,6 +8,10 @@
 extern "C" {
 #endif
 
+#include "common.h"
+#include "hydrogen_p.h"
+#include "x25519.h"
+
 #define hydro_sign_CHALLENGEBYTES 32
 #define hydro_sign_NONCEBYTES 32
 #define hydro_sign_PREHASHBYTES 64

--- a/impl/x25519.h
+++ b/impl/x25519.h
@@ -14,6 +14,9 @@
 extern "C" {
 #endif
 
+#include "common.h"
+#include "hydrogen_p.h"
+
 #if defined(__GNUC__) && defined(__SIZEOF_INT128__)
 # define hydro_x25519_WBITS 64
 #else

--- a/impl/x25519.h
+++ b/impl/x25519.h
@@ -4,6 +4,16 @@
  * MIT License (MIT)
  */
 
+#ifndef hydrogen_x25519_H
+#define hydrogen_x25519_H
+
+#ifdef __cplusplus
+# ifdef __GNUC__
+#  pragma GCC diagnostic ignored "-Wlong-long"
+# endif
+extern "C" {
+#endif
+
 #if defined(__GNUC__) && defined(__SIZEOF_INT128__)
 # define hydro_x25519_WBITS 64
 #else
@@ -381,3 +391,9 @@ hydro_x25519_sc_montmul(hydro_x25519_scalar_t out, const hydro_x25519_scalar_t a
         out[i] = hydro_x25519_umaal(&carry, out[i], need_add, hydro_x25519_sc_p[i]);
     }
 }
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* hydrogen_x25519_H */


### PR DESCRIPTION
This pull request implements header guards for all the headers and fixes the includes to make the headers valid as independent entities.

This greatly improves the experience of editing the code in syntax highlighting editors/IDEs because they can now find/highlight the identifiers defined in the included headers.
