### PR TITLE
Fix up CMake formatting

### DIFF
--- a/.cmake-format.json
+++ b/.cmake-format.json
@@ -1,0 +1,46 @@
+{
+  "additional_commands": {
+    "add_custom_command": {
+      "kwargs": {
+        "ARGS": "*",
+        "COMMAND": 1,
+        "OUTPUT": 1,
+        "WORKING_DIRECTORY": 1
+      }
+    },
+    "configure_package_config_file": {
+      "kwargs": {
+        "INSTALL_DESTINATION": 1
+      }
+    },
+    "include_directories": {
+      "kwargs": {
+        "SYSTEM": 0
+      }
+    },
+    "list": {
+      "kwargs": {
+        "APPEND": 1,
+        "OUTPUT_VARIABLE": 1,
+        "PREPEND": 1,
+        "TRANSFORM": 1
+      }
+    },
+    "set_target_properties": {
+      "kwargs": {
+        "EXCLUDE_FROM_ALL": 1,
+        "EXCLUDE_FROM_DEFAULT_BUILD": 1,
+        "PROPERTIES": 0
+      }
+    },
+    "string": {
+      "kwargs": {
+        "APPEND": 1
+      }
+    }
+  },
+  "keyword_case": "upper",
+  "line_width": 99,
+  "max_subargs_per_line": 6
+}
+

--- a/.cmake-format.json
+++ b/.cmake-format.json
@@ -35,7 +35,8 @@
     },
     "string": {
       "kwargs": {
-        "APPEND": 1
+        "APPEND": 1,
+        "CONCAT": 1
       }
     }
   },

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,14 +39,18 @@ set(arduino_files "library.properties")
 
 # Compile options
 
-get_setting(target_arch STRING "Target system architecture (fed to the compiler's -march=...).")
+get_setting(target_arch STRING "Target system architecture (fed to the compiler's -march=XXX).")
 if(NOT target_arch AND NOT CMAKE_CROSSCOMPILING)
   set(target_arch native)
 endif()
 
+get_setting(target_device STRING "Target device identifier (defines HYDRO_TARGET_DEVICE_XXX).")
+
 set(compile_options
     # --- GNU, Clang ---
     $<$<OR:$<C_COMPILER_ID:AppleClang>,$<C_COMPILER_ID:Clang>,$<C_COMPILER_ID:GNU>>:
+    # ---- Definitions ----
+    $<$<BOOL:${target_device}>:-DHYDRO_TARGET_DEVICE_${target_device}>
     # ---- Optimizations ----
     -Os $<$<BOOL:${target_arch}>:-march=${target_arch}> -fno-exceptions
     # ---- Warnings ----
@@ -69,6 +73,8 @@ set(compile_options
     >
     # --- MSVC ---
     $<$<C_COMPILER_ID:MSVC>:
+    # ---- Definitions ----
+    $<$<BOOL:${target_device}>:/DHYDRO_TARGET_DEVICE_${target_device}>
     # ---- Optimizations ----
     /Os /EHsc
     # ---- Warnings ----

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,14 +6,9 @@ include(CMakePackageConfigHelpers)
 include(GNUInstallDirs)
 
 string(TOUPPER "${PROJECT_NAME}" setting_prefix)
-function(get_setting
-         setting_name
-         setting_type
-         setting_description)
+function(get_setting setting_name setting_type setting_description)
   string(TOUPPER "${setting_prefix}_${setting_name}" setting_external_name)
-  set("${setting_external_name}"
-      ""
-      CACHE "${setting_type}" "${setting_description}")
+  set("${setting_external_name}" "" CACHE "${setting_type}" "${setting_description}")
   set("${setting_name}" "${${setting_external_name}}" PARENT_SCOPE)
 endfunction()
 
@@ -44,57 +39,51 @@ set(arduino_files "library.properties")
 
 # Compile options
 
-get_setting(target_arch STRING
-            "Target system architecture (fed to the compiler's -march=...).")
+get_setting(target_arch STRING "Target system architecture (fed to the compiler's -march=...).")
 if(NOT target_arch AND NOT CMAKE_CROSSCOMPILING)
   set(target_arch native)
 endif()
 
-set(
-  compile_options
-  # GNU, Clang
-  $<$<OR:$<C_COMPILER_ID:AppleClang>,$<C_COMPILER_ID:Clang>,$<C_COMPILER_ID:GNU>>:
-  # Optimizations
-  -Os $<$<BOOL:${target_arch}>:-march=${target_arch}> -fno-exceptions
-  # Warnings
-  -Wall
-  -Wextra
-  -Wmissing-prototypes
-  -Wdiv-by-zero
-  -Wbad-function-cast
-  -Wcast-align
-  -Wcast-qual
-  -Wfloat-equal
-  -Wmissing-declarations
-  -Wnested-externs
-  -Wno-unknown-pragmas
-  -Wpointer-arith
-  -Wredundant-decls
-  -Wstrict-prototypes
-  -Wswitch-enum
-  -Wno-type-limits>
-  # MSVC
-  $<$<C_COMPILER_ID:MSVC>:
-  # Optimizations
-  /Os /EHsc
-  # Warnings
-  /WX
-  /W4
-  /wd4197 # suppress warning "top-level volatile in cast is ignored"
-  /wd4146 # suppress warning "unary minus operator applied to unsigned type,
-          # result still unsigned"
-  /wd4310 # suppress warning "cast truncates constant value"
-  >)
+set(compile_options
+    # --- GNU, Clang ---
+    $<$<OR:$<C_COMPILER_ID:AppleClang>,$<C_COMPILER_ID:Clang>,$<C_COMPILER_ID:GNU>>:
+    # ---- Optimizations ----
+    -Os $<$<BOOL:${target_arch}>:-march=${target_arch}> -fno-exceptions
+    # ---- Warnings ----
+    -Wall
+    -Wextra
+    -Wmissing-prototypes
+    -Wdiv-by-zero
+    -Wbad-function-cast
+    -Wcast-align
+    -Wcast-qual
+    -Wfloat-equal
+    -Wmissing-declarations
+    -Wnested-externs
+    -Wno-unknown-pragmas
+    -Wpointer-arith
+    -Wredundant-decls
+    -Wstrict-prototypes
+    -Wswitch-enum
+    -Wno-type-limits
+    >
+    # --- MSVC ---
+    $<$<C_COMPILER_ID:MSVC>:
+    # ---- Optimizations ----
+    /Os /EHsc
+    # ---- Warnings ----
+    /WX
+    /W4
+    /wd4197 # * suppress warning "top-level volatile in cast is ignored"
+    /wd4146 # * suppress warning "unary minus operator applied to unsigned type, result still
+            #   unsigned"
+    /wd4310 # * suppress warning "cast truncates constant value"
+    >)
 
 # Prefix project files with the project root
 
 function(prefix_project_paths list_name)
-  list(TRANSFORM
-       "${list_name}"
-       PREPEND
-       "${PROJECT_SOURCE_DIR}/"
-       OUTPUT_VARIABLE
-       prefixed_list)
+  list(TRANSFORM "${list_name}" PREPEND "${PROJECT_SOURCE_DIR}/" OUTPUT_VARIABLE prefixed_list)
   set("project_${list_name}" ${prefixed_list} PARENT_SCOPE)
 endfunction()
 
@@ -110,10 +99,9 @@ add_library("${PROJECT_NAME}::${PROJECT_NAME}" ALIAS "${PROJECT_NAME}")
 
 target_sources("${PROJECT_NAME}" PRIVATE ${project_source_files})
 
-target_include_directories(
-  "${PROJECT_NAME}"
-  PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
-         $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+target_include_directories("${PROJECT_NAME}"
+                           PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
+                                  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 
 target_compile_options("${PROJECT_NAME}" PRIVATE ${compile_options})
 
@@ -144,16 +132,12 @@ set(config_file_name "${PROJECT_NAME}-config.cmake")
 set(config_template_file "${PROJECT_SOURCE_DIR}/cmake/${config_file_name}.in")
 set(config_file "${PROJECT_BINARY_DIR}/${config_file_name}")
 
-configure_package_config_file("${config_template_file}"
-                              "${config_file}"
-                              INSTALL_DESTINATION
-                              "${install_config_dir}")
+configure_package_config_file("${config_template_file}" "${config_file}"
+                              INSTALL_DESTINATION "${install_config_dir}")
 
 install(FILES "${config_file}" DESTINATION "${install_config_dir}")
 
-export(EXPORT "${targets_export_name}"
-       FILE "${targets_export_file}"
-       NAMESPACE "${PROJECT_NAME}::")
+export(EXPORT "${targets_export_name}" FILE "${targets_export_file}" NAMESPACE "${PROJECT_NAME}::")
 
 export(PACKAGE "${PROJECT_NAME}")
 
@@ -170,23 +154,22 @@ target_link_libraries("${tests_executable}" "${PROJECT_NAME}")
 add_test(NAME "${tests_executable}" COMMAND "${tests_executable}")
 
 if(CMAKE_CROSSCOMPILING)
-  # Disable tests executable by default when cross-compiling (as it will fail to
-  # build when, e.g., cross-compiling for Arduino/AVR).
+  # Disable tests executable by default when cross-compiling (as it will fail to build when, e.g.,
+  # cross-compiling for Arduino/AVR).
   set_target_properties("${tests_executable}"
-                        PROPERTIES EXCLUDE_FROM_ALL
-                                   1
-                                   EXCLUDE_FROM_DEFAULT_BUILD
-                                   1)
+                        PROPERTIES
+                        EXCLUDE_FROM_ALL 1
+                        EXCLUDE_FROM_DEFAULT_BUILD 1)
 else()
   # Otherwise, auto-run the tests on build.
   add_custom_command(OUTPUT "${tests_run_file}"
                      DEPENDS "${tests_executable}"
-                     COMMAND cmake ARGS -E remove "${tests_run_file}"
-                     COMMAND ctest ARGS
-                             -C
-                             $<CONFIGURATION>
-                             --output-on-failure
-                     COMMAND cmake ARGS -E touch "${tests_run_file}"
+                     COMMAND cmake
+                     ARGS -E remove "${tests_run_file}"
+                     COMMAND ctest
+                     ARGS -C $<CONFIGURATION> --output-on-failure
+                     COMMAND cmake
+                     ARGS -E touch "${tests_run_file}"
                      WORKING_DIRECTORY "${PROJECT_BINARY_DIR}")
   add_custom_target("${tests_run_target}" ALL DEPENDS "${tests_run_file}")
 endif()
@@ -195,18 +178,19 @@ endif()
 
 set(arduino_package_file "${PROJECT_BINARY_DIR}/hydrogen-crypto.zip")
 
-# Use the relative versions of the file path lists or else the full paths will
-# end up in the generated archive.
+# Use the relative versions of the file path lists or else the full paths will end up in the
+# generated archive.
 add_custom_command(OUTPUT "${arduino_package_file}"
-                   COMMAND cmake ARGS
-                           -E
-                           tar cf "${arduino_package_file}"
-                           --format=zip
-                           --
-                           ${source_files}
-                           ${header_files}
-                           ${arduino_files}
+                   COMMAND cmake
+                   ARGS -E
+                        tar
+                        cf
+                        "${arduino_package_file}"
+                        --format=zip
+                        --
+                        ${source_files}
+                        ${header_files}
+                        ${arduino_files}
                    WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}")
 
-add_custom_target("${PROJECT_NAME}-arduino-package"
-                  DEPENDS "${arduino_package_file}")
+add_custom_target("${PROJECT_NAME}-arduino-package" DEPENDS "${arduino_package_file}")

--- a/cmake/arduino-avr-toolchain.cmake
+++ b/cmake/arduino-avr-toolchain.cmake
@@ -1,6 +1,7 @@
 # Cross-compilation file for the Arduino/AVR toolchain.
 
 # To use, pass -DCMAKE_TOOLCHAIN_FILE=cmake/arduino-avr-toolchain.cmake in your CMake command line.
+# You can specify the target device MCU identifier with -DHYDROGEN_ARDUINO_AVR_TARGET_DEVICE=XXX.
 
 cmake_minimum_required(VERSION 3.12)
 
@@ -97,6 +98,8 @@ endfunction()
 find_in_toolchain(avr_gcc)
 find_in_toolchain(avr_gcc_ranlib)
 find_in_toolchain(avr_gcc_ar)
+find_in_toolchain(avr_gcc_nm)
+find_in_toolchain(avr_strip)
 
 # Configure CMake toolchain settings
 
@@ -105,13 +108,15 @@ set(CMAKE_C_COMPILER "${avr_gcc}")
 set(CMAKE_ASM_COMPILER "${avr_gcc}")
 set(CMAKE_RANLIB "${avr_gcc_ranlib}")
 set(CMAKE_AR "${avr_gcc_ar}")
+set(CMAKE_NM "${avr_gcc_nm}")
+set(CMAKE_STRIP "${avr_strip}")
 
 set(CMAKE_C_OUTPUT_EXTENSION .o)
 set(CMAKE_ASM_OUTPUT_EXTENSION .o)
 
-# Add compile flags
+# Set compile flags
 
-string(APPEND CMAKE_C_FLAGS " -mmcu=${target_device} -Os -mcall-prologues -fno-exceptions"
+string(CONCAT CMAKE_C_FLAGS " -mmcu=${target_device} -mcall-prologues -fno-exceptions"
                             " -ffunction-sections -fdata-sections -flto")
 
 # Add include directories

--- a/cmake/arduino-avr-toolchain.cmake
+++ b/cmake/arduino-avr-toolchain.cmake
@@ -4,16 +4,16 @@
 
 cmake_minimum_required(VERSION 3.12)
 
-set(setting_prefix ARDUINO_AVR)
+set(project_setting_prefix HYDROGEN)
+function(set_project_setting setting_name setting_value)
+  set("${project_setting_prefix}_${setting_name}" "${setting_value}" CACHE INTERNAL "")
+endfunction()
+
+set(setting_prefix "${project_setting_prefix}_ARDUINO_AVR")
 function(get_setting setting_name setting_type setting_description)
   string(TOUPPER "${setting_prefix}_${setting_name}" setting_external_name)
   set("${setting_external_name}" "" CACHE "${setting_type}" "${setting_description}")
   set("${setting_name}" "${${setting_external_name}}" PARENT_SCOPE)
-endfunction()
-
-set(project_setting_prefix HYDROGEN)
-function(set_project_setting setting_name setting_value)
-  set("${project_setting_prefix}_${setting_name}" "${setting_value}" CACHE INTERNAL "")
 endfunction()
 
 # Target device setting

--- a/cmake/arduino-avr-toolchain.cmake
+++ b/cmake/arduino-avr-toolchain.cmake
@@ -1,19 +1,13 @@
 # Cross-compilation file for the Arduino/AVR toolchain.
 
-# To use, pass -DCMAKE_TOOLCHAIN_FILE=cmake/arduino-avr-toolchain.cmake in your
-# CMake command line.
+# To use, pass -DCMAKE_TOOLCHAIN_FILE=cmake/arduino-avr-toolchain.cmake in your CMake command line.
 
 cmake_minimum_required(VERSION 3.12)
 
 set(setting_prefix ARDUINO_AVR)
-function(get_setting
-         setting_name
-         setting_type
-         setting_description)
+function(get_setting setting_name setting_type setting_description)
   string(TOUPPER "${setting_prefix}_${setting_name}" setting_external_name)
-  set("${setting_external_name}"
-      ""
-      CACHE "${setting_type}" "${setting_description}")
+  set("${setting_external_name}" "" CACHE "${setting_type}" "${setting_description}")
   set("${setting_name}" "${${setting_external_name}}" PARENT_SCOPE)
 endfunction()
 
@@ -27,9 +21,7 @@ endif()
 if("${target_device}" STREQUAL atmega328p)
   set(hw_type ATMEGA328)
 else()
-  message(
-    FATAL_ERROR
-      "Unrecognized ${setting_prefix}_TARGET_DEVICE value ${target_device}")
+  message(FATAL_ERROR "Unrecognized ${setting_prefix}_TARGET_DEVICE value ${target_device}")
 endif()
 
 # Find Arduino SDK home
@@ -48,26 +40,21 @@ if(NOT sdk_dir)
   # Windows
   if(WIN32)
     list(APPEND arduino_home_dir_guesses "C:/Program Files (x86)/Arduino"
-                "C:/Program Files/Arduino")
+                                         "C:/Program Files/Arduino")
   endif()
 
   # macOS
   if(APPLE)
-    list(APPEND arduino_home_dir_guesses
-                "/Applications/Arduino.app/Contents/Java")
+    list(APPEND arduino_home_dir_guesses "/Applications/Arduino.app/Contents/Java")
   endif()
 
   # Linux/Unix
   if(UNIX AND NOT APPLE)
-    list(APPEND arduino_home_dir_guesses "/usr/share/arduino"
-                "/usr/local/share/arduino")
+    list(APPEND arduino_home_dir_guesses "/usr/share/arduino" "/usr/local/share/arduino")
   endif()
 
   if(DEFINED arduino_home_dir_guesses)
-    foreach(arduino_home_dir_guess
-            IN
-            LISTS
-            arduino_home_dir_guesses)
+    foreach(arduino_home_dir_guess IN LISTS arduino_home_dir_guesses)
       if(IS_DIRECTORY "${arduino_home_dir_guess}")
         set(sdk_dir "${arduino_home_dir_guess}")
         break()
@@ -77,11 +64,9 @@ if(NOT sdk_dir)
 endif()
 
 if(NOT sdk_dir)
-  message(
-    FATAL_ERROR
-      "Couldn't determine Arduino SDK home directory. "
-      "Try passing -D${setting_prefix}_SDK_DIR=... to the CMake command line, or "
-      "set the ARDUINO_SDK_PATH environment variable.")
+  message(FATAL_ERROR "Couldn't determine Arduino SDK home directory. "
+                      "Try passing -D${setting_prefix}_SDK_DIR=... to the CMake command line, or "
+                      "set the ARDUINO_SDK_PATH environment variable.")
 endif()
 
 # Locate toolchain programs
@@ -90,10 +75,7 @@ set(arduino_tools_dir "${sdk_dir}/hardware/tools/avr/bin")
 set(program_prefix "${setting_prefix}_PROGRAM")
 function(find_in_toolchain program_name)
   string(TOUPPER "${program_prefix}_${program_name}" program_external_name)
-  string(REPLACE "_"
-                 "-"
-                 program_file_name
-                 "${program_name}")
+  string(REPLACE "_" "-" program_file_name "${program_name}")
 
   find_program("${program_external_name}" "${program_file_name}"
                PATHS "${arduino_tools_dir}"
@@ -124,16 +106,13 @@ set(CMAKE_ASM_OUTPUT_EXTENSION .o)
 
 # Add compile flags
 
-string(APPEND
-       CMAKE_C_FLAGS
-       " -mmcu=${target_device} -Os -mcall-prologues -fno-exceptions"
-       " -ffunction-sections -fdata-sections -flto"
-       " -DHYDRO_TARGET_DEVICE_${hw_type}")
+string(APPEND CMAKE_C_FLAGS " -mmcu=${target_device} -Os -mcall-prologues -fno-exceptions"
+                            " -ffunction-sections -fdata-sections -flto"
+                            " -DHYDRO_TARGET_DEVICE_${hw_type}")
 
 # Add include directories
 
-include_directories(SYSTEM
-                    "${sdk_dir}/hardware/arduino/avr/cores/arduino"
-                    "${sdk_dir}/hardware/arduino/avr/variants/standard"
-                    "${sdk_dir}/hardware/arduino/cores/arduino"
-                    "${sdk_dir}/hardware/arduino/variants/standard")
+include_directories(SYSTEM "${sdk_dir}/hardware/arduino/avr/cores/arduino"
+                           "${sdk_dir}/hardware/arduino/avr/variants/standard"
+                           "${sdk_dir}/hardware/arduino/cores/arduino"
+                           "${sdk_dir}/hardware/arduino/variants/standard")

--- a/cmake/arduino-avr-toolchain.cmake
+++ b/cmake/arduino-avr-toolchain.cmake
@@ -11,6 +11,11 @@ function(get_setting setting_name setting_type setting_description)
   set("${setting_name}" "${${setting_external_name}}" PARENT_SCOPE)
 endfunction()
 
+set(project_setting_prefix HYDROGEN)
+function(set_project_setting setting_name setting_value)
+  set("${project_setting_prefix}_${setting_name}" "${setting_value}" CACHE INTERNAL "")
+endfunction()
+
 # Target device setting
 
 get_setting(target_device STRING "Target Arduino device MCU identifier.")
@@ -19,7 +24,7 @@ if(NOT target_device)
 endif()
 
 if("${target_device}" STREQUAL atmega328p)
-  set(hw_type ATMEGA328)
+  set_project_setting(TARGET_DEVICE ATMEGA328)
 else()
   message(FATAL_ERROR "Unrecognized ${setting_prefix}_TARGET_DEVICE value ${target_device}")
 endif()
@@ -107,8 +112,7 @@ set(CMAKE_ASM_OUTPUT_EXTENSION .o)
 # Add compile flags
 
 string(APPEND CMAKE_C_FLAGS " -mmcu=${target_device} -Os -mcall-prologues -fno-exceptions"
-                            " -ffunction-sections -fdata-sections -flto"
-                            " -DHYDRO_TARGET_DEVICE_${hw_type}")
+                            " -ffunction-sections -fdata-sections -flto")
 
 # Add include directories
 


### PR DESCRIPTION
- Add a cmake_format configuration file and re-format with [`cmake_format 0.5.3`](https://pypi.org/project/cmake-format/).
- Shift the setting that controls `HYDRO_TARGET_DEVICE_XXX` definitions to the main `CMakeLists.txt`, so it can be configured by projects importing `libhydrogen` via `add_subdirectory`. The Arduino toolchain still automatically initializes this setting based on the target MCU.
- Prefix Arduino CMake toolchain options with `HYDROGEN_*`.