### PR TITLE
Fix cmake not found error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -169,11 +169,11 @@ else()
   # Otherwise, auto-run the tests on build.
   add_custom_command(OUTPUT "${tests_run_file}"
                      DEPENDS "${tests_executable}"
-                     COMMAND cmake
+                     COMMAND ${CMAKE_COMMAND}
                      ARGS -E remove "${tests_run_file}"
-                     COMMAND ctest
+                     COMMAND ${CMAKE_CTEST_COMMAND}
                      ARGS -C $<CONFIGURATION> --output-on-failure
-                     COMMAND cmake
+                     COMMAND ${CMAKE_COMMAND}
                      ARGS -E touch "${tests_run_file}"
                      WORKING_DIRECTORY "${PROJECT_BINARY_DIR}")
   add_custom_target("${tests_run_target}" ALL DEPENDS "${tests_run_file}")
@@ -186,7 +186,7 @@ set(arduino_package_file "${PROJECT_BINARY_DIR}/hydrogen-crypto.zip")
 # Use the relative versions of the file path lists or else the full paths will end up in the
 # generated archive.
 add_custom_command(OUTPUT "${arduino_package_file}"
-                   COMMAND cmake
+                   COMMAND ${CMAKE_COMMAND}
                    ARGS -E
                         tar
                         cf


### PR DESCRIPTION
When I was trying to add `libhydrogen` into `vcpkg`(https://github.com/microsoft/vcpkg/pull/7436), the `vcpkg`'s CI system reports it fails on Linux and macOS: 
https://dev.azure.com/vcpkg/public/_build/results?buildId=8415
https://dev.azure.com/vcpkg/public/_build/results?buildId=8418
I downloaded the port failure logs and got this:
>[1/6] /usr/bin/cc  -I/home/vcpkg/myagent/_work/4/s/buildtrees/libhydrogen/src/a1d93becec-95c16f0d25 -fPIC -g   -Os -march=native -fno-exceptions -Wall -Wextra -Wmissing-prototypes -Wdiv-by-zero -Wbad-function-cast -Wcast-align -Wcast-qual -Wfloat-equal -Wmissing-declarations -Wnested-externs -Wno-unknown-pragmas -Wpointer-arith -Wredundant-decls -Wstrict-prototypes -Wswitch-enum -Wno-type-limits -MD -MT CMakeFiles/hydrogen-tests.dir/tests/tests.c.o -MF CMakeFiles/hydrogen-tests.dir/tests/tests.c.o.d -o CMakeFiles/hydrogen-tests.dir/tests/tests.c.o   -c /home/vcpkg/myagent/_work/4/s/buildtrees/libhydrogen/src/a1d93becec-95c16f0d25/tests/tests.c
[2/6] /usr/bin/cc  -I/home/vcpkg/myagent/_work/4/s/buildtrees/libhydrogen/src/a1d93becec-95c16f0d25 -fPIC -g   -Os -march=native -fno-exceptions -Wall -Wextra -Wmissing-prototypes -Wdiv-by-zero -Wbad-function-cast -Wcast-align -Wcast-qual -Wfloat-equal -Wmissing-declarations -Wnested-externs -Wno-unknown-pragmas -Wpointer-arith -Wredundant-decls -Wstrict-prototypes -Wswitch-enum -Wno-type-limits -MD -MT CMakeFiles/hydrogen.dir/hydrogen.c.o -MF CMakeFiles/hydrogen.dir/hydrogen.c.o.d -o CMakeFiles/hydrogen.dir/hydrogen.c.o   -c /home/vcpkg/myagent/_work/4/s/buildtrees/libhydrogen/src/a1d93becec-95c16f0d25/hydrogen.c
[3/6] : && /home/vcpkg/myagent/_work/4/s/downloads/tools/cmake-3.14.0-linux/cmake-3.14.0-Linux-x86_64/bin/cmake -E remove libhydrogen.a && /usr/bin/ar qc libhydrogen.a  CMakeFiles/hydrogen.dir/hydrogen.c.o && /usr/bin/ranlib libhydrogen.a && :
[4/6] : && /usr/bin/cc -fPIC -g   CMakeFiles/hydrogen-tests.dir/tests/tests.c.o  -o hydrogen-tests  libhydrogen.a && :
[5/6] cd /mnt/buildtrees/libhydrogen/x64-linux-dbg && cmake -E remove /mnt/buildtrees/libhydrogen/x64-linux-dbg/hydrogen-run-tests.done && ctest -C Debug --output-on-failure && cmake -E touch /mnt/buildtrees/libhydrogen/x64-linux-dbg/hydrogen-run-tests.done
FAILED: hydrogen-run-tests.done 
cd /mnt/buildtrees/libhydrogen/x64-linux-dbg && cmake -E remove /mnt/buildtrees/libhydrogen/x64-linux-dbg/hydrogen-run-tests.done && ctest -C Debug --output-on-failure && cmake -E touch /mnt/buildtrees/libhydrogen/x64-linux-dbg/hydrogen-run-tests.done
/bin/sh: 1: cmake: not found
ninja: build stopped: subcommand failed.

It complains that `/bin/sh: 1: cmake: not found`.
I am not sure how is CMake installed on `vcpkg`'s CI agents, it just does not work.

This patch uses CMake's predefined ${CMAKE_COMMAND} and ${CMAKE_CTEST_COMMAND} variables, and it works fine. 

