### PR TITLE
Added support for px4 nuttx

### DIFF
--- a/impl/random.h
+++ b/impl/random.h
@@ -68,6 +68,20 @@ hydro_random_init(void)
 
 ISR(WDT_vect) {}
 
+#elif  defined(__PX4_NUTTX)
+
+static int
+hydro_random_init(void)
+{
+    int fd = open("/dev/random", O_RDONLY);
+
+    read(fd, hydro_random_context.state, gimli_BLOCKBYTES);
+
+    hydro_random_context.counter = ~LOAD64_LE(hydro_random_context.state);
+
+    return 0;
+}
+
 #elif (defined(ESP32) || defined(ESP8266)) && !defined(__unix__)
 
 // Important: RF *must* be activated on ESP board


### PR DESCRIPTION
The goal of this pool request is to add support of libhydrogen for nuttx real-time os, which is used in the PX4 platform. I would like to add a security layer based on libhydrogen to Mavlink protocol which is used on the PX4 platform for telemetry. After this pool request it will be possible to generate secure seed on PX4 hardware.