### PR TITLE
random: add support for RIOT

### DIFF
--- a/impl/random.h
+++ b/impl/random.h
@@ -21,6 +21,8 @@ static TLS struct {
 # include "random/unix.h"
 #elif defined(TARGET_LIKE_MBED)
 # include "random/mbed.h"
+#elif defined(RIOT_VERSION)
+# include "random/riot.h"
 #else
 #error Unsupported platform
 #endif

--- a/impl/random/riot.h
+++ b/impl/random/riot.h
@@ -1,0 +1,10 @@
+#include <random.h>
+
+static int
+hydro_random_init(void)
+{
+    random_bytes(hydro_random_context.state, sizeof(hydro_random_context.state));
+    hydro_random_context.counter = ~LOAD64_LE(hydro_random_context.state);
+
+    return 0;
+}


### PR DESCRIPTION
Add support for [RIOT-OS](https://github.com/RIOT-OS/RIOT) to libhydrogen so we can just use the upstream version in the [RIOT `pkg`](https://github.com/RIOT-OS/RIOT/tree/master/pkg/libhydrogen).