### PR TITLE
Add RT-Thread RTOS Support

### DIFF
--- a/SConscript
+++ b/SConscript
@@ -1,13 +1,18 @@
-Import('RTT_ROOT')
-Import('rtconfig')
 from building import *
 
-objs = []
-cwd     = GetCurrentDir()
+if GetDepend('PKG_USING_LIBHYDROGEN'):
+    Import('RTT_ROOT')
+    Import('rtconfig')
 
-src     = 'hydrogen.c'
-path   =  [cwd]
+    objs    = []
+    cwd     = GetCurrentDir()
 
-group = DefineGroup('libhydrogen', src, depend = ['PKG_USING_LIBHYDROGEN'], CPPPATH = path)
+    src     = 'hydrogen.c'
+    path    = [cwd]
 
-Return('group')
+    group   = DefineGroup('libhydrogen', src, depend = ['PKG_USING_LIBHYDROGEN'], CPPPATH = path)
+
+    Return('group')
+
+else:
+    print('The scons script only supports RT-Thread, please use Makefiles/zig/cmake.')

--- a/SConscript
+++ b/SConscript
@@ -1,0 +1,13 @@
+Import('RTT_ROOT')
+Import('rtconfig')
+from building import *
+
+objs = []
+cwd     = GetCurrentDir()
+
+src     = 'hydrogen.c'
+path   =  [cwd]
+
+group = DefineGroup('libhydrogen', src, depend = ['PKG_USING_LIBHYDROGEN'], CPPPATH = path)
+
+Return('group')

--- a/impl/random.h
+++ b/impl/random.h
@@ -25,6 +25,8 @@ static TLS struct {
 # include "random/riot.h"
 #elif defined(STM32F4)
 # include "random/stm32.h"
+#elif defined(__RTTHREAD__)
+# include "random/rtthread.h"
 #else
 # error Unsupported platform
 #endif

--- a/impl/random/rtthread.h
+++ b/impl/random/rtthread.h
@@ -6,6 +6,16 @@
 #include <rtdbg.h>
 
 static int
+hydrogen_init(void) {
+    if (hydro_init() != 0) {
+        abort();
+    }
+    LOG_I("libhydrogen initialized");
+    return 0;
+}
+INIT_APP_EXPORT(hydrogen_init);
+
+static int
 hydro_random_init(void)
 {
     const char       ctx[hydro_hash_CONTEXTBYTES] = { 'h', 'y', 'd', 'r', 'o', 'P', 'R', 'G' };

--- a/impl/random/rtthread.h
+++ b/impl/random/rtthread.h
@@ -1,0 +1,27 @@
+#include <rtthread.h>
+#include <hw_rng.h>
+
+#define DBG_TAG "libhydrogen"
+#define DBG_LVL DBG_LOG
+#include <rtdbg.h>
+
+static int
+hydro_random_init(void)
+{
+    const char       ctx[hydro_hash_CONTEXTBYTES] = { 'h', 'y', 'd', 'r', 'o', 'P', 'R', 'G' };
+    hydro_hash_state st;
+    uint16_t         ebits = 0;
+
+    hydro_hash_init(&st, ctx, NULL);
+
+    while (ebits < 256) {
+        uint32_t r = rt_hwcrypto_rng_update();
+        hydro_hash_update(&st, (const uint32_t *) &r, sizeof r);
+        ebits += 32;
+    }
+
+    hydro_hash_final(&st, hydro_random_context.state, sizeof hydro_random_context.state);
+    hydro_random_context.counter = ~LOAD64_LE(hydro_random_context.state);
+
+    return 0;
+}


### PR DESCRIPTION
Hi,

This PR adds support for [RT-Thread](https://www.rt-thread.io/), which is a RTOS that supports [150+ boadrs](https://www.rt-thread.io/board.html).

Previously, I ported [libsodium ](https://packages.rt-thread.org/en/search.html?search=libsodium) to [RT-Thread Package center](https://packages.rt-thread.org/en/index.html), but recently I notice that libhydrogen may fit better for embedded devices.

Hope you are interested,
Han

![ezgif com-gif-maker](https://user-images.githubusercontent.com/15157070/167179926-678c7b3b-f908-47a5-a684-6dc46b6aaeeb.gif)