### PR TITLE
Add RT-Thread Support

### DIFF
--- a/impl/random.h
+++ b/impl/random.h
@@ -25,6 +25,8 @@ static TLS struct {
 # include "random/riot.h"
 #elif defined(STM32F4)
 # include "random/stm32.h"
+#elif defined(__RTTHREAD__)
+# include "random/rtthread.h"
 #else
 # error Unsupported platform
 #endif

--- a/impl/random/rtthread.h
+++ b/impl/random/rtthread.h
@@ -6,6 +6,16 @@
 #include <rtdbg.h>
 
 static int
+hydrogen_init(void) {
+    if (hydro_init() != 0) {
+        abort();
+    }
+    LOG_I("libhydrogen initialized");
+    return 0;
+}
+INIT_APP_EXPORT(hydrogen_init);
+
+static int
 hydro_random_init(void)
 {
     const char       ctx[hydro_hash_CONTEXTBYTES] = { 'h', 'y', 'd', 'r', 'o', 'P', 'R', 'G' };

--- a/impl/random/rtthread.h
+++ b/impl/random/rtthread.h
@@ -1,0 +1,27 @@
+#include <rtthread.h>
+#include <hw_rng.h>
+
+#define DBG_TAG "libhydrogen"
+#define DBG_LVL DBG_LOG
+#include <rtdbg.h>
+
+static int
+hydro_random_init(void)
+{
+    const char       ctx[hydro_hash_CONTEXTBYTES] = { 'h', 'y', 'd', 'r', 'o', 'P', 'R', 'G' };
+    hydro_hash_state st;
+    uint16_t         ebits = 0;
+
+    hydro_hash_init(&st, ctx, NULL);
+
+    while (ebits < 256) {
+        uint32_t r = rt_hwcrypto_rng_update();
+        hydro_hash_update(&st, (const uint32_t *) &r, sizeof r);
+        ebits += 32;
+    }
+
+    hydro_hash_final(&st, hydro_random_context.state, sizeof hydro_random_context.state);
+    hydro_random_context.counter = ~LOAD64_LE(hydro_random_context.state);
+
+    return 0;
+}


### PR DESCRIPTION
Hi,

It seems like you prefer to keep `SConscript` outside of the main repo. I understand that this could cause some inconveniences for you. Thus, this PR only contains minimum ports for RT-Thread.

As for the package `libhydrogen` in RT-Thread package center, currently it points to my fork, such that I can continue add examples for `libhydrogen` on RT-Thread without effecting the upstream repo.

https://github.com/wuhanstudio/libhydrogen

Hope this works.