### PR TITLE
random: rt-thread: log error rather than abort in the main thread

### DIFF
--- a/impl/random/rtthread.h
+++ b/impl/random/rtthread.h
@@ -8,7 +8,7 @@
 static int
 hydrogen_init(void) {
     if (hydro_init() != 0) {
-        abort();
+        LOG_E("libhydrogen failed to initialize");
     }
     LOG_I("libhydrogen initialized");
     return 0;


### PR DESCRIPTION
Hi,

This PR adds an error message if `libhydrogen` fails to initialize rather than abort the main thread, causing all other components unable to initialize.

![image](https://user-images.githubusercontent.com/15157070/167704853-a33c2fe6-0462-485d-9bd8-d79fe2a7dea0.png)
