### PR TITLE
Fix the `sub` function so it computes the correct result even if the inputs are not the result of a `propagate`.

### DIFF
--- a/impl/x25519.h
+++ b/impl/x25519.h
@@ -105,14 +105,14 @@ hydro_x25519_add(hydro_x25519_fe out, const hydro_x25519_fe a, const hydro_x2551
 static void
 hydro_x25519_sub(hydro_x25519_fe out, const hydro_x25519_fe a, const hydro_x25519_fe b)
 {
-    hydro_x25519_sdlimb_t carry = -38;
+    hydro_x25519_sdlimb_t carry = -76;
     int                   i;
 
     for (i = 0; i < hydro_x25519_NLIMBS; i++) {
         out[i] = (hydro_x25519_limb_t) (carry = carry + a[i] - b[i]);
         carry >>= hydro_x25519_WBITS;
     }
-    hydro_x25519_propagate(out, (hydro_x25519_limb_t) (1 + carry));
+    hydro_x25519_propagate(out, (hydro_x25519_limb_t) (2 + carry));
 }
 
 static void


### PR DESCRIPTION
The way `sub` is used in STROBE and libhydrogen does not encounter this
case because `sub` is always used on results which have been fully
`propagate`d, but if the field arithmetic code were copied and used in
another context, this bug may surface.

This was fixed in STROBE here:
https://sourceforge.net/p/strobe/code/ci/7d7f605380f573d06484accb61d08c5f4674b35a/
