### PR TITLE
Add Linux kernel/module support

### DIFF
--- a/hydrogen.h
+++ b/hydrogen.h
@@ -1,9 +1,15 @@
 #ifndef hydrogen_H
 #define hydrogen_H
 
+#if !(defined(__linux__) && defined(__KERNEL__))
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#endif
+
+#ifdef __GNUC__
+#pragma GCC diagnostic ignored "-Wdeclaration-after-statement"
+#endif
 
 #ifdef __cplusplus
 #ifdef __GNUC__

--- a/impl/common.h
+++ b/impl/common.h
@@ -1,9 +1,18 @@
+#if defined(__linux__) && defined(__KERNEL__)
+#define TLS /* Danger: at most one call into hydro_*() at a time */
+#define CHAR_BIT 8
+#define abort BUG
+#define uint_fast16_t uint16_t
+#define errno hydro_errno
+static int errno;
+#else
 #include <errno.h>
 #include <limits.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
+#endif
 
 #if !defined(__unix__) && (defined(__APPLE__) || defined(__linux__))
 #define __unix__ 1

--- a/impl/random.h
+++ b/impl/random.h
@@ -17,6 +17,8 @@ static TLS struct {
 # include "random/windows.h"
 #elif defined(__wasi__)
 # include "random/wasi.h"
+#elif defined(__linux__) && defined(__KERNEL__)
+# include "random/linux_kernel.h"
 #elif defined(__unix__)
 # include "random/unix.h"
 #elif defined(TARGET_LIKE_MBED)

--- a/impl/random/linux_kernel.h
+++ b/impl/random/linux_kernel.h
@@ -1,0 +1,9 @@
+static int
+hydro_random_init(void)
+{
+    get_random_bytes(&hydro_random_context.state,
+        sizeof hydro_random_context.state);
+    hydro_random_context.counter = ~LOAD64_LE(hydro_random_context.state);
+
+    return 0;
+}


### PR DESCRIPTION
This adds basic support for building/using hydrogen in a Linux kernel (module) tree.

Right now, only one instance at a time is supported (or they'd clash on the random number pool, breaking security). To remedy this, I think the individual functions in `impl/random.h` except for `hydro_random_buf_deterministic` can be rewritten to use the kernel APIs (only when building in a Linux kernel or module tree) instead of Gimli. Alternatively, Linux kernel specific spinlocks can be introduced into those functions, but that's worse scalability. Either way, `hydro_random_buf_deterministic` can stay as-is, because it does not use the shared global state.

For our current usage, one instance at a time was sufficient (can be guaranteed with locking in the calling code), so I did not bother improving this yet.