### PR TITLE
Add random support for CH32 MCUs

### DIFF
--- a/impl/random.h
+++ b/impl/random.h
@@ -29,6 +29,8 @@ static TLS struct {
 # include "random/stm32.h"
 #elif defined(__RTTHREAD__)
 # include "random/rtthread.h"
+#elif defined(CH32V30x_D8) || defined(CH32V30x_D8C)
+# include "random/ch32.h"
 #else
 # error Unsupported platform
 #endif

--- a/impl/random/ch32.h
+++ b/impl/random/ch32.h
@@ -1,0 +1,34 @@
+#if defined(CH32V30x_D8) || defined(CH32V30x_D8C)
+#include <ch32v30x_rng.h>
+#else
+# error CH32 implementation missing!
+#endif
+
+static int
+hydro_random_init(void)
+{
+    // Enable RNG clock source
+    RCC_AHBPeriphClockCmd(RCC_AHBPeriph_RNG, ENABLE);
+
+    // RNG Peripheral enable
+    RNG_Cmd(ENABLE);
+
+    const char       ctx[hydro_hash_CONTEXTBYTES] = { 'h', 'y', 'd', 'r', 'o', 'P', 'R', 'G' };
+    hydro_hash_state st;
+    uint16_t         ebits = 0;
+
+    hydro_hash_init(&st, ctx, NULL);
+
+    while (ebits < 256) {
+        while (RNG_GetFlagStatus(RNG_FLAG_DRDY) == RESET);
+        uint32_t r = RNG_GetRandomNumber();
+
+        hydro_hash_update(&st, (const uint32_t *) &r, sizeof r);
+        ebits += 32;
+    }
+
+    hydro_hash_final(&st, hydro_random_context.state, sizeof hydro_random_context.state);
+    hydro_random_context.counter = ~LOAD64_LE(hydro_random_context.state);
+
+    return 0;
+}


### PR DESCRIPTION
Currently, only CH32V30x series have hardware random number generator.

http://www.wch-ic.com/products/CH32V307.html