### PR TITLE
ChibiOS/HAL support

### DIFF
--- a/Makefile.chibios
+++ b/Makefile.chibios
@@ -1,0 +1,43 @@
+MCU ?= cortex-m7
+WFLAGS ?= -Wall -Wextra -Wmissing-prototypes -Wdiv-by-zero -Wbad-function-cast -Wcast-align -Wcast-qual -Wfloat-equal -Wmissing-declarations -Wnested-externs -Wno-unknown-pragmas -Wpointer-arith -Wredundant-decls -Wstrict-prototypes -Wswitch-enum -Wno-type-limits
+CFLAGS ?= -Os -mcpu=$(MCU) -mthumb -mpure-code -fno-exceptions -ffunction-sections -fdata-sections -flto $(WFLAGS)
+CFLAGS += -DCHIBIOS
+CFLAGS += -I.
+OBJ = hydrogen.o
+AR ?= arm-none-eabi-ar
+CC = arm-none-eabi-gcc
+RANLIB ?= arm-none-eabi-ranlib
+
+SRC = \
+	hydrogen.c \
+	hydrogen.h \
+	impl/common.h \
+	impl/core.h \
+	impl/gimli-core.h \
+	impl/hash.h \
+	impl/hydrogen_p.h \
+	impl/kdf.h \
+	impl/kx.h \
+	impl/pwhash.h \
+	impl/random.h \
+	impl/secretbox.h \
+	impl/sign.h \
+	impl/x25519.h
+
+all: lib
+
+lib: libhydrogen.a
+
+$(OBJ): $(SRC)
+
+libhydrogen.a: $(OBJ)
+	$(AR) -r $@ $^
+	$(RANLIB) $@
+
+.PHONY: clean
+
+clean:
+	rm -f libhydrogen.a $(OBJ)
+	rm -f tests/tests tests/*.done
+
+distclean: clean

--- a/impl/random.h
+++ b/impl/random.h
@@ -31,6 +31,8 @@ static TLS struct {
 # include "random/rtthread.h"
 #elif defined(CH32V30x_D8) || defined(CH32V30x_D8C)
 # include "random/ch32.h"
+#elif defined(CHIBIOS)
+# include "random/chibios.h"
 #else
 # error Unsupported platform
 #endif

--- a/impl/random/chibios.h
+++ b/impl/random/chibios.h
@@ -1,0 +1,26 @@
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+
+/* Declarations from ChibiOS HAL TRNG module */
+
+extern struct hal_trng_driver TRNGD1;
+
+void trngStart(struct hal_trng_driver *, const void *);
+bool trngGenerate(struct hal_trng_driver *, size_t size, uint8_t *);
+
+
+static int
+hydro_random_init(void)
+{
+    trngStart(&TRNGD1, NULL);
+
+    if (trngGenerate(&TRNGD1, sizeof hydro_random_context.state, hydro_random_context.state)) {
+        return 1;
+    }
+
+    hydro_random_context.counter = ~LOAD64_LE(hydro_random_context.state);
+
+    return 0;
+}


### PR DESCRIPTION
Added support for the TRNG module of the ChibiOS/HAL. The TRNG module is compatible with most STM32. Tested this on a STM32H7.