### PR TITLE
Added Zephyr integration

### DIFF
--- a/impl/random.h
+++ b/impl/random.h
@@ -11,6 +11,8 @@ static TLS struct {
 # include "random/esp32.h"
 #elif defined(PARTICLE) && defined(PLATFORM_ID) && PLATFORM_ID > 2 && !defined(__unix__)
 # include "random/particle.h"
+#elif defined(__ZEPHYR__)
+# include "random/zephyr.h"
 #elif (defined(NRF52832_XXAA) || defined(NRF52832_XXAB)) && !defined(__unix__)
 # include "random/nrf52832.h"
 #elif defined(_WIN32)

--- a/impl/random/zephyr.h
+++ b/impl/random/zephyr.h
@@ -1,0 +1,13 @@
+#include <zephyr/random/rand32.h>
+
+static int
+hydro_random_init(void)
+{
+    if (sys_csrand_get(&hydro_random_context.state, sizeof hydro_random_context.state) != 0) {
+        return -1;
+    }
+
+    hydro_random_context.counter = ~LOAD64_LE(hydro_random_context.state);
+
+    return 0;
+}


### PR DESCRIPTION
We've tried to use `libhydrogen` in our project which is based on the nRF Connect SDK. And found out that `libhydrogen` incorrectly assumed the old nRF SDK.
Here is an adaptation for any Zephyr-based platform.