### PR TITLE
Meson build system

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v3

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -29,14 +29,14 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
 
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+      uses: github/codeql-action/autobuild@v3
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v3
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -23,10 +23,21 @@ jobs:
       fail-fast: false
       matrix:
         language: [ 'c-cpp' ]
+        autobuild_force_build_system: ['cmake', 'meson']
 
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
+
+    - name: Maybe remove non-CMake build systems
+      if: matrix.autobuild_force_build_system == 'cmake'
+      run: |
+        rm -vrf Makefile* meson.build
+
+    - name: Maybe remove non-Meson build systems
+      if: matrix.autobuild_force_build_system == 'meson'
+      run: |
+        rm -vrf Makefile* CMakeLists.txt cmake/
 
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v3

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         language: [ 'c-cpp' ]
-        autobuild_force_build_system: ['cmake', 'meson']
+        autobuild_force_build_system: ['cmake', 'make', 'meson']
 
     steps:
     - name: Checkout repository
@@ -33,6 +33,11 @@ jobs:
       if: matrix.autobuild_force_build_system == 'cmake'
       run: |
         rm -vrf Makefile* meson.build
+
+    - name: Maybe remove non-Make build systems
+      if: matrix.autobuild_force_build_system == 'make'
+      run: |
+        rm -vrf CMakeLists.txt cmake/ meson.build
 
     - name: Maybe remove non-Meson build systems
       if: matrix.autobuild_force_build_system == 'meson'

--- a/meson.build
+++ b/meson.build
@@ -53,6 +53,14 @@ test('tests', tests)
 
 install_headers(files('hydrogen.h'))
 
+pkgconfig = import('pkgconfig')
+pkgconfig.generate(
+  libhydrogen,
+  name: 'libhydrogen',
+  description: 'Lightweight, secure, easy-to-use crypto library suitable for constrained environments.',
+  url: 'https://libhydrogen.org/',
+)
+
 libhydrogen_dep = declare_dependency(
   include_directories: include_dirs,
   link_with: libhydrogen,

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,59 @@
+project(
+  'libhydrogen',
+  'c',
+  license: 'ISC',
+  default_options: [
+    'buildtype=minsize',
+    'default_library=static',
+    'warning_level=2',
+  ],
+)
+
+cc = meson.get_compiler('c')
+
+cflags = cc.get_supported_arguments(
+  '-Wbad-function-cast',
+  '-Wcast-align',
+  '-Wcast-qual',
+  '-Wdiv-by-zero',
+  '-Wfloat-equal',
+  '-Wmissing-declarations',
+  '-Wmissing-prototypes',
+  '-Wnested-externs',
+  '-Wno-type-limits',
+  '-Wno-unknown-pragmas',
+  '-Wpointer-arith',
+  '-Wredundant-decls',
+  '-Wstrict-prototypes',
+  '-Wswitch-enum',
+  '-fno-exceptions',
+  '-mtune=native',
+)
+add_project_arguments(cflags, language: 'c')
+
+include_dirs = include_directories('.')
+
+sources = files(
+  'hydrogen.c',
+)
+
+libhydrogen = library(
+  'hydrogen',
+  sources,
+  include_directories: include_dirs,
+  install: true,
+)
+
+tests = executable(
+  'tests',
+  files('tests/tests.c'),
+  link_with: libhydrogen,
+)
+test('tests', tests)
+
+install_headers(files('hydrogen.h'))
+
+libhydrogen_dep = declare_dependency(
+  include_directories: include_dirs,
+  link_with: libhydrogen,
+)


### PR DESCRIPTION
Hi, Frank!

This branch adds a `meson.build` file for building libhydrogen. Not sure if you want another build system in your tree, but since I saw you have a few Makefiles and CMake already, I thought I would check :-)

If you aren't familiar with meson and its [wrap dependency system ](https://mesonbuild.com/Wrap-dependency-system-manual.html), this makes it easy for a meson project to take a dependency on another one, especially and even if the dependency is not available from the OS.

E.g., I want to depend on libhydrogen from a project that I'm working on that uses meson, but libhydrogen is not available from my OS's packages repository, so I added these commits to my project:

https://github.com/edmonds/vacon/commit/045c9202d13b9db2736f2770530d117390791441
https://github.com/edmonds/vacon/commit/82bce87f0f65e11f92adb30fd6e0ce035d5e2cb9

Meson then takes care of automatically downloading libhydrogen and building it into my project if the dependency can't be satisfied from the system:

```
$ meson setup build
[…]
Run-time dependency libhydrogen found: NO (tried pkgconfig and cmake)
Looking for a fallback subproject for the dependency libhydrogen
Initialized empty Git repository in /home/edmonds/proj/vacon/subprojects/libhydrogen/.git/
remote: Enumerating objects: 69, done.
remote: Counting objects: 100% (69/69), done.
remote: Compressing objects: 100% (63/63), done.
remote: Total 69 (delta 10), reused 25 (delta 3), pack-reused 0
Unpacking objects: 100% (69/69), 51.52 KiB | 2.58 MiB/s, done.
From https://github.com/edmonds/libhydrogen
 * branch            f8782bf07b5211ff0cb37b5b7a6f7b5c6b52626b -> FETCH_HEAD
HEAD is now at f8782bf Add meson build system

Executing subproject libhydrogen

libhydrogen| Project name: libhydrogen
libhydrogen| Project version: undefined
libhydrogen| C compiler for the host machine: sccache cc (gcc 13.2.0 "cc (Debian 13.2.0-16.1) 13.2.0")
libhydrogen| C linker for the host machine: cc ld.bfd 2.42
libhydrogen| Compiler for C supports arguments -Wbad-function-cast: YES
libhydrogen| Compiler for C supports arguments -Wcast-align: YES
libhydrogen| Compiler for C supports arguments -Wcast-qual: YES
libhydrogen| Compiler for C supports arguments -Wdiv-by-zero: YES
libhydrogen| Compiler for C supports arguments -Wfloat-equal: YES
libhydrogen| Compiler for C supports arguments -Wmissing-declarations: YES
libhydrogen| Compiler for C supports arguments -Wmissing-prototypes: YES
libhydrogen| Compiler for C supports arguments -Wnested-externs: YES
libhydrogen| Compiler for C supports arguments -Wno-type-limits: YES
libhydrogen| Compiler for C supports arguments -Wno-unknown-pragmas: YES
libhydrogen| Compiler for C supports arguments -Wpointer-arith: YES
libhydrogen| Compiler for C supports arguments -Wredundant-decls: YES
libhydrogen| Compiler for C supports arguments -Wstrict-prototypes: YES
libhydrogen| Compiler for C supports arguments -Wswitch-enum: YES
libhydrogen| Compiler for C supports arguments -fno-exceptions: YES
libhydrogen| Compiler for C supports arguments -mtune=native: YES
libhydrogen| Build targets in project: 3
libhydrogen| Subproject libhydrogen finished.

Dependency libhydrogen from subproject subprojects/libhydrogen found: YES undefined
[…]
```

I also added pkg-config .pc file generation, but if you want a `meson.build` without that functionality that commit can be omitted.

Thanks!