### PR TITLE
hydrogen.h: Add `#ifndef __cplusplus` guard for pragma not valid in C++

### DIFF
--- a/hydrogen.h
+++ b/hydrogen.h
@@ -7,8 +7,10 @@
 #include <stdlib.h>
 #endif
 
+#ifndef __cplusplus
 #ifdef __GNUC__
 #pragma GCC diagnostic ignored "-Wdeclaration-after-statement"
+#endif
 #endif
 
 #ifdef __cplusplus


### PR DESCRIPTION
This commit wraps the GCC pragma to ignore -Wdeclaration-after-statement diagnostics in an `#ifndef __cplusplus` guard since this pragma isn't needed when compiling in C++ mode.

Without this change, I get the following diagnostic from g++ when compiling a C++ project that includes hydrogen.h:

    ../subprojects/libhydrogen/hydrogen.h:11:32: warning: option ‘-Wdeclaration-after-statement’ is valid for C/ObjC but not for C++ [-Wpragmas]
       11 | #pragma GCC diagnostic ignored "-Wdeclaration-after-statement"
          |                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~