### PR TITLE
Add CHERIoT support

### DIFF
--- a/impl/common.h
+++ b/impl/common.h
@@ -14,6 +14,10 @@ static int errno;
 #    include <string.h>
 #endif
 
+#if defined (__CHERIOT__)
+static int errno;
+#endif
+
 #if !defined(__unix__) && (defined(__APPLE__) || defined(__linux__))
 #    define __unix__ 1
 #endif

--- a/impl/random.h
+++ b/impl/random.h
@@ -35,6 +35,8 @@ static TLS struct {
 #    include "random/ch32.h"
 #elif defined(CHIBIOS)
 #    include "random/chibios.h"
+#elif defined(__CHERIOT__)
+#    include "random/cheriot.h"
 #else
 #    error Unsupported platform
 #endif

--- a/impl/random/cheriot.h
+++ b/impl/random/cheriot.h
@@ -1,0 +1,24 @@
+uint32_t rand_32();
+
+static int
+hydro_random_init(void)
+{
+    const char       ctx[hydro_hash_CONTEXTBYTES] = { 'h', 'y', 'd', 'r', 'o', 'P', 'R', 'G' };
+    hydro_hash_state st;
+    uint16_t         ebits = 0;
+
+    hydro_hash_init(&st, ctx, NULL);
+
+    while (ebits < 256) {
+        uint32_t r = rand_32();
+        
+        //delay(10);
+        hydro_hash_update(&st, (const uint32_t *) &r, sizeof r);
+        ebits += 32;
+    }
+
+    hydro_hash_final(&st, hydro_random_context.state, sizeof hydro_random_context.state);
+    hydro_random_context.counter = ~LOAD64_LE(hydro_random_context.state);
+
+    return 0;
+}

--- a/impl/random/cheriot.h
+++ b/impl/random/cheriot.h
@@ -11,8 +11,6 @@ hydro_random_init(void)
 
     while (ebits < 256) {
         uint32_t r = rand_32();
-        
-        //delay(10);
         hydro_hash_update(&st, (const uint32_t *) &r, sizeof r);
         ebits += 32;
     }


### PR DESCRIPTION
This PR adds support for [CHERIoT](https://cheriot.org/), an RTOS designed to provide hardware based memory safety on embedded systems using [Capability Hardware Enhanced RISC Instructions](https://en.wikipedia.org/wiki/Capability_Hardware_Enhanced_RISC_Instructions)

It was developed by [Configured Things](https://www.configuredthings.com/) with funding from the [Digital Security by Design](https://www.dsbd.tech) program.