### PR TITLE
Fix incorrect argument for `get_random_bytes` in `linux_kernel.h`

### DIFF
--- a/impl/random/linux_kernel.h
+++ b/impl/random/linux_kernel.h
@@ -1,7 +1,7 @@
 static int
 hydro_random_init(void)
 {
-    get_random_bytes(&hydro_random_context.state, sizeof hydro_random_context.state);
+    get_random_bytes(hydro_random_context.state, sizeof hydro_random_context.state);
     hydro_random_context.counter = ~LOAD64_LE(hydro_random_context.state);
 
     return 0;


### PR DESCRIPTION
It seems to me that `get_random_bytes` takes a pointer as its first argument, not a double pointer.