### PR TITLE
Zephyr removed "rand32.h" in 2024, current name is "random.h"

### DIFF
--- a/impl/random/zephyr.h
+++ b/impl/random/zephyr.h
@@ -1,4 +1,4 @@
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 
 static int
 hydro_random_init(void)


### PR DESCRIPTION
I'm adding the library to a Zephyr board, and it's not compiling as is. The needed fix is very minor, motivated by [this Zephyr commit](https://github.com/zephyrproject-rtos/zephyr/commit/7498329d59b64cd407ced13a8daf478253635e5d).