### PR TITLE
Add support for pico-sdk

### DIFF
--- a/impl/random.h
+++ b/impl/random.h
@@ -37,6 +37,11 @@ static TLS struct {
 #    include "random/chibios.h"
 #elif defined(__CHERIOT__)
 #    include "random/cheriot.h"
+#elif defined(PICO_BUILD)
+#    ifndef LIB_PICO_RAND
+#        error pico-sdk detected but pico_rand not configured
+#    endif
+#    include "random/pico-sdk.h"
 #else
 #    error Unsupported platform
 #endif

--- a/impl/random/pico-sdk.h
+++ b/impl/random/pico-sdk.h
@@ -1,0 +1,35 @@
+#ifndef RANDOM_PICO_H_
+#define RANDOM_PICO_H_
+
+#include "pico/rand.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+static int
+hydro_random_init(void)
+{
+    const char       ctx[hydro_hash_CONTEXTBYTES] = { 'h', 'y', 'd', 'r', 'o', 'P', 'R', 'G' };
+    hydro_hash_state st;
+    uint16_t         ebits = 0;
+
+    hydro_hash_init(&st, ctx, NULL);
+
+    while (ebits < 256) {
+        uint32_t r = get_rand_32();
+        hydro_hash_update(&st, (const uint32_t *) &r, sizeof r);
+        ebits += 32;
+    }
+
+    hydro_hash_final(&st, hydro_random_context.state, sizeof hydro_random_context.state);
+    hydro_random_context.counter = ~LOAD64_LE(hydro_random_context.state);
+
+    return 0;
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* RANDOM_PICO_H_ */


### PR DESCRIPTION
This PR adds support for RaspberryPi's [pico-sdk](https://github.com/raspberrypi/pico-sdk). It makes using libhydrogen on the RP2040 and RP2350 possible.
Seeding the rand before using it is not required on this platform, it will automatically be seeded.
I have verified that tests.c run successful (no asserts). Run time of all tests in tests.c took 6075ms on the RP2350 and 22445ms on the RP2040.
Template for the new header file was [particle.h](/impl/random/particle.h)