### PR TITLE
pico-sdk: use get_rand_64 instead of get_rand_32

### DIFF
--- a/impl/random/pico-sdk.h
+++ b/impl/random/pico-sdk.h
@@ -17,9 +17,9 @@ hydro_random_init(void)
     hydro_hash_init(&st, ctx, NULL);
 
     while (ebits < 256) {
-        uint32_t r = get_rand_32();
-        hydro_hash_update(&st, (const uint32_t *) &r, sizeof r);
-        ebits += 32;
+        uint64_t r = get_rand_64();
+        hydro_hash_update(&st, (const uint64_t *) &r, sizeof r);
+        ebits += 64;
     }
 
     hydro_hash_final(&st, hydro_random_context.state, sizeof hydro_random_context.state);


### PR DESCRIPTION
get_rand_32, get_rand_64, and get_rand_128 generate random numbers. libhydrogen currently uses get_rand_32. This works. However, it would be more efficient to use get_rand_64. This would provide the same level of randomness but fewer function calls, which should minimally improve performance. get_rand_128 returns a struct containing two 64-bit random numbers. Extracting the random numbers would require additional code, which carries the risk of introducing errors and impairing readability.

Closes https://github.com/jedisct1/libhydrogen/issues/162